### PR TITLE
Fix multi-select new line splitting

### DIFF
--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -16,8 +16,8 @@ const Passage = ({
 }: {
   bibleData: WordProps[];
 }) => {
-  const { ctxStudyId, ctxPassageProps, ctxSetPassageProps, ctxStudyMetadata, 
-    ctxSelectedWords, ctxSetSelectedWords, ctxSetNumSelectedWords, 
+  const { ctxStudyId, ctxPassageProps, ctxSetPassageProps, ctxStudyMetadata,
+    ctxSetStudyMetadata, ctxSelectedWords, ctxSetSelectedWords, ctxSetNumSelectedWords,
     ctxSelectedStrophes, ctxSetSelectedStrophes, ctxSetNumSelectedStrophes,
     ctxStructureUpdateType, ctxSetStructureUpdateType, ctxAddToHistory
   } = useContext(FormatContext);
@@ -29,35 +29,37 @@ const Passage = ({
     if (ctxStructureUpdateType !== StructureUpdateType.none &&
       (ctxSelectedWords.length > 0 || ctxSelectedStrophes.length >= 1)) {
 
+      const newMetadata = structuredClone(ctxStudyMetadata);
+
       const sortedWords = [...ctxSelectedWords].sort((a, b) => a.wordId - b.wordId);
       let selectedWordId = (sortedWords.length > 0) ? sortedWords[0].wordId : 0;
       const lastSelectedWordId = (sortedWords.length > 0) ? sortedWords[sortedWords.length - 1].wordId : selectedWordId;
 
       if (ctxStructureUpdateType == StructureUpdateType.newLine) {
-        ctxStudyMetadata.words[selectedWordId] = {
-          ...(ctxStudyMetadata.words[selectedWordId] || {}),
+        newMetadata.words[selectedWordId] = {
+          ...(newMetadata.words[selectedWordId] || {}),
           lineBreak: true,
           ignoreNewLine: undefined
         };
 
         sortedWords.slice(1).forEach(w => {
-          const hasBreak = w.newLine || ctxStudyMetadata.words[w.wordId]?.lineBreak;
+          const hasBreak = w.newLine || newMetadata.words[w.wordId]?.lineBreak;
           if (hasBreak) {
-            ctxStudyMetadata.words[w.wordId] = {
-              ...(ctxStudyMetadata.words[w.wordId] || {}),
+            newMetadata.words[w.wordId] = {
+              ...(newMetadata.words[w.wordId] || {}),
               lineBreak: undefined,
               ignoreNewLine: true,
             };
-          } else if (ctxStudyMetadata.words[w.wordId]) {
-            delete ctxStudyMetadata.words[w.wordId].lineBreak;
-            delete ctxStudyMetadata.words[w.wordId].ignoreNewLine;
+          } else if (newMetadata.words[w.wordId]) {
+            delete newMetadata.words[w.wordId].lineBreak;
+            delete newMetadata.words[w.wordId].ignoreNewLine;
           }
         });
 
         const nextWordId = lastSelectedWordId + 1;
         if (bibleData.some(word => word.wordId === nextWordId)) {
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             lineBreak: true,
             ignoreNewLine: undefined
           };
@@ -66,12 +68,12 @@ const Passage = ({
       else if (ctxStructureUpdateType == StructureUpdateType.mergeWithPrevLine) {
         const foundIndex = bibleData.findLastIndex(word =>
           word.wordId <= selectedWordId &&
-          (word.newLine || ctxStudyMetadata.words[word.wordId]?.lineBreak)
+          (word.newLine || newMetadata.words[word.wordId]?.lineBreak)
         );
         if (foundIndex !== -1) {
           const id = bibleData[foundIndex].wordId;
-          ctxStudyMetadata.words[id] = {
-            ...(ctxStudyMetadata.words[id] || {}),
+          newMetadata.words[id] = {
+            ...(newMetadata.words[id] || {}),
             lineBreak: undefined,
             ignoreNewLine: true,
           };
@@ -79,9 +81,9 @@ const Passage = ({
 
         for (let i = selectedWordId; i <= lastSelectedWordId; i++) {
           const word = bibleData.find(w => w.wordId === i);
-          if (word?.newLine || ctxStudyMetadata.words[i]?.lineBreak) {
-            ctxStudyMetadata.words[i] = {
-              ...(ctxStudyMetadata.words[i] || {}),
+          if (word?.newLine || newMetadata.words[i]?.lineBreak) {
+            newMetadata.words[i] = {
+              ...(newMetadata.words[i] || {}),
               lineBreak: undefined,
               ignoreNewLine: true,
             };
@@ -90,24 +92,24 @@ const Passage = ({
 
         const nextWordId = lastSelectedWordId + 1;
         if (bibleData.some(word => word.wordId === nextWordId)) {
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             lineBreak: true,
             ignoreNewLine: undefined
           };
         }
       }
       else if (ctxStructureUpdateType == StructureUpdateType.mergeWithNextLine) {
-        ctxStudyMetadata.words[selectedWordId] = {
-          ...(ctxStudyMetadata.words[selectedWordId] || {}),
+        newMetadata.words[selectedWordId] = {
+          ...(newMetadata.words[selectedWordId] || {}),
           lineBreak: true,
           ignoreNewLine: undefined
         };
 
         sortedWords.slice(1).forEach(w => {
-          if (w.newLine || ctxStudyMetadata.words[w.wordId]?.lineBreak) {
-            ctxStudyMetadata.words[w.wordId] = {
-              ...(ctxStudyMetadata.words[w.wordId] || {}),
+          if (w.newLine || newMetadata.words[w.wordId]?.lineBreak) {
+            newMetadata.words[w.wordId] = {
+              ...(newMetadata.words[w.wordId] || {}),
               lineBreak: undefined,
               ignoreNewLine: true,
             };
@@ -116,34 +118,34 @@ const Passage = ({
 
         const foundIndex = bibleData.findIndex(word =>
           word.wordId > lastSelectedWordId &&
-          (word.newLine || ctxStudyMetadata.words[word.wordId]?.lineBreak)
+          (word.newLine || newMetadata.words[word.wordId]?.lineBreak)
         );
         if (foundIndex !== -1) {
           const id = bibleData[foundIndex].wordId;
-          ctxStudyMetadata.words[id] = {
-            ...(ctxStudyMetadata.words[id] || {}),
+          newMetadata.words[id] = {
+            ...(newMetadata.words[id] || {}),
             lineBreak: undefined,
             ignoreNewLine: true,
           };
         }
       }
       else if (ctxStructureUpdateType == StructureUpdateType.newStrophe) {
-        ctxStudyMetadata.words[selectedWordId] = {
-          ...ctxStudyMetadata.words[selectedWordId],
+        newMetadata.words[selectedWordId] = {
+          ...newMetadata.words[selectedWordId],
           stropheDiv: true,
         };
 
         sortedWords.slice(1).forEach(w => {
-          if (ctxStudyMetadata.words[w.wordId]) {
-            delete ctxStudyMetadata.words[w.wordId].stropheDiv;
-            delete ctxStudyMetadata.words[w.wordId].stropheMd;
+          if (newMetadata.words[w.wordId]) {
+            delete newMetadata.words[w.wordId].stropheDiv;
+            delete newMetadata.words[w.wordId].stropheMd;
           }
         });
 
         const nextWordId = lastSelectedWordId + 1;
         if (bibleData.some(word => word.wordId === nextWordId)) {
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             stropheDiv: true
           };
         }
@@ -153,34 +155,34 @@ const Passage = ({
           const sortedStrophes = [...ctxSelectedStrophes].sort((a, b) => a.stropheId - b.stropheId);
           sortedStrophes.forEach(s => {
             const firstWordId = s.lines[0].words[0].wordId;
-            delete ctxStudyMetadata.words[firstWordId]?.stropheDiv;
-            delete ctxStudyMetadata.words[firstWordId]?.stropheMd;
+            delete newMetadata.words[firstWordId]?.stropheDiv;
+            delete newMetadata.words[firstWordId]?.stropheMd;
           });
           const lastWordId = sortedStrophes.at(-1)!.lines.at(-1)!.words.at(-1)!.wordId;
           const nextWordId = lastWordId + 1;
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             stropheDiv: true
           };
         } else {
           const foundIndex = bibleData.findLastIndex(word =>
-            word.wordId <= selectedWordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
+            word.wordId <= selectedWordId && newMetadata.words[word.wordId]?.stropheDiv
           );
           if (foundIndex !== -1) {
-            delete ctxStudyMetadata.words[bibleData[foundIndex].wordId].stropheDiv;
-            delete ctxStudyMetadata.words[bibleData[foundIndex].wordId].stropheMd;
+            delete newMetadata.words[bibleData[foundIndex].wordId].stropheDiv;
+            delete newMetadata.words[bibleData[foundIndex].wordId].stropheMd;
           }
 
           for (let i = selectedWordId; i <= lastSelectedWordId; i++) {
-            if (ctxStudyMetadata.words[i]) {
-              delete ctxStudyMetadata.words[i].stropheDiv;
-              delete ctxStudyMetadata.words[i].stropheMd;
+            if (newMetadata.words[i]) {
+              delete newMetadata.words[i].stropheDiv;
+              delete newMetadata.words[i].stropheMd;
             }
           }
 
           const nextWordId = lastSelectedWordId + 1;
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             stropheDiv: true
           };
         }
@@ -189,39 +191,39 @@ const Passage = ({
         if (ctxSelectedStrophes.length >= 1) {
           const sortedStrophes = [...ctxSelectedStrophes].sort((a, b) => a.stropheId - b.stropheId);
           const firstWordId = sortedStrophes[0].lines[0].words[0].wordId;
-          ctxStudyMetadata.words[firstWordId] = {
-            ...(ctxStudyMetadata.words[firstWordId] || {}),
+          newMetadata.words[firstWordId] = {
+            ...(newMetadata.words[firstWordId] || {}),
             stropheDiv: true
           };
           const foundIndex = bibleData.findIndex(word =>
-            word.wordId > sortedStrophes.at(-1)!.lines.at(-1)!.words.at(-1)!.wordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
+            word.wordId > sortedStrophes.at(-1)!.lines.at(-1)!.words.at(-1)!.wordId && newMetadata.words[word.wordId]?.stropheDiv
           );
           if (foundIndex !== -1) {
-            ctxStudyMetadata.words[bibleData[foundIndex].wordId] = {
-              ...ctxStudyMetadata.words[bibleData[foundIndex].wordId],
+            newMetadata.words[bibleData[foundIndex].wordId] = {
+              ...newMetadata.words[bibleData[foundIndex].wordId],
               stropheDiv: false,
               stropheMd: undefined
             };
           }
         } else {
-          ctxStudyMetadata.words[selectedWordId] = {
-            ...(ctxStudyMetadata.words[selectedWordId] || {}),
+          newMetadata.words[selectedWordId] = {
+            ...(newMetadata.words[selectedWordId] || {}),
             stropheDiv: true
           };
 
           for (let i = selectedWordId + 1; i <= lastSelectedWordId; i++) {
-            if (ctxStudyMetadata.words[i]) {
-              delete ctxStudyMetadata.words[i].stropheDiv;
-              delete ctxStudyMetadata.words[i].stropheMd;
+            if (newMetadata.words[i]) {
+              delete newMetadata.words[i].stropheDiv;
+              delete newMetadata.words[i].stropheMd;
             }
           }
 
           const foundIndex = bibleData.findIndex(word =>
-            word.wordId > lastSelectedWordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
+            word.wordId > lastSelectedWordId && newMetadata.words[word.wordId]?.stropheDiv
           );
           if (foundIndex !== -1) {
-            ctxStudyMetadata.words[bibleData[foundIndex].wordId] = {
-              ...ctxStudyMetadata.words[bibleData[foundIndex].wordId],
+            newMetadata.words[bibleData[foundIndex].wordId] = {
+              ...newMetadata.words[bibleData[foundIndex].wordId],
               stropheDiv: false,
               stropheMd: undefined
             };
@@ -238,15 +240,15 @@ const Passage = ({
         const lastStrophe = sortedStrophes[sortedStrophes.length - 1];
         const lastWordIdInStrophes = lastStrophe.lines.at(-1)?.words.at(-1)?.wordId || selectedWordId;
 
-        ctxStudyMetadata.words[selectedWordId] = {
-          ...ctxStudyMetadata.words[selectedWordId],
+        newMetadata.words[selectedWordId] = {
+          ...newMetadata.words[selectedWordId],
           stanzaDiv: true,
         };
 
         const nextWordId = lastWordIdInStrophes + 1;
         if (bibleData.some(word => word.wordId === nextWordId)) {
-          ctxStudyMetadata.words[nextWordId] = {
-            ...(ctxStudyMetadata.words[nextWordId] || {}),
+          newMetadata.words[nextWordId] = {
+            ...(newMetadata.words[nextWordId] || {}),
             stanzaDiv: true
           };
         }
@@ -258,20 +260,20 @@ const Passage = ({
         }
         // find the word with a stanza div marker for this stanza
         const lastStanzaDiv = bibleData.findLastIndex(word =>
-          word.wordId <= selectedWordId && ctxStudyMetadata.words[word.wordId]?.stanzaDiv
+          word.wordId <= selectedWordId && newMetadata.words[word.wordId]?.stanzaDiv
         );
         if (lastStanzaDiv >= 0) {
-          delete ctxStudyMetadata.words[bibleData[lastStanzaDiv].wordId].stanzaDiv;
-          delete ctxStudyMetadata.words[bibleData[lastStanzaDiv].wordId].stanzaMd;
+          delete newMetadata.words[bibleData[lastStanzaDiv].wordId].stanzaDiv;
+          delete newMetadata.words[bibleData[lastStanzaDiv].wordId].stanzaMd;
         }
 
         // find the index to the first word of the next strophe
         const foundIndex = bibleData.findIndex(word =>
-           word.wordId > selectedWordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
+           word.wordId > selectedWordId && newMetadata.words[word.wordId]?.stropheDiv
         );
         if (foundIndex !== -1) {
-          ctxStudyMetadata.words[bibleData[foundIndex].wordId] = {
-            ...ctxStudyMetadata.words[bibleData[foundIndex].wordId],
+          newMetadata.words[bibleData[foundIndex].wordId] = {
+            ...newMetadata.words[bibleData[foundIndex].wordId],
             stanzaDiv: true
           };
         }
@@ -281,27 +283,28 @@ const Passage = ({
           // there should always be at least one line and one word in a strophe          
           selectedWordId = ctxSelectedStrophes[0].lines.at(0)?.words.at(0)?.wordId || 0;
         }
-        ctxStudyMetadata.words[selectedWordId] = {
-          ...(ctxStudyMetadata.words[selectedWordId] || {}),
+        newMetadata.words[selectedWordId] = {
+          ...(newMetadata.words[selectedWordId] || {}),
           stanzaDiv: true
         };
         const foundIndex = bibleData.findIndex(word =>
-          word.wordId > selectedWordId && (ctxStudyMetadata.words[word.wordId]?.stanzaDiv && ctxStudyMetadata.words[word.wordId]?.stropheDiv)
+          word.wordId > selectedWordId && (newMetadata.words[word.wordId]?.stanzaDiv && newMetadata.words[word.wordId]?.stropheDiv)
         );
         if (foundIndex !== -1) {
-          ctxStudyMetadata.words[bibleData[foundIndex].wordId] = {
-            ...ctxStudyMetadata.words[bibleData[foundIndex].wordId],
+          newMetadata.words[bibleData[foundIndex].wordId] = {
+            ...newMetadata.words[bibleData[foundIndex].wordId],
             stanzaDiv: false,
             stanzaMd: undefined
           };
         }
       }
-      
-      ctxAddToHistory(ctxStudyMetadata);
-      const updatedPassageProps = mergeData(bibleData, ctxStudyMetadata);
+
+      ctxSetStudyMetadata(newMetadata);
+      ctxAddToHistory(newMetadata);
+      const updatedPassageProps = mergeData(bibleData, newMetadata);
       ctxSetPassageProps(updatedPassageProps);
 
-      updateMetadataInDb(ctxStudyId, ctxStudyMetadata);
+      updateMetadataInDb(ctxStudyId, newMetadata);
 
       ctxSetSelectedStrophes([]);
       ctxSetNumSelectedStrophes(0);

--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -41,7 +41,14 @@ const Passage = ({
         };
 
         sortedWords.slice(1).forEach(w => {
-          if (ctxStudyMetadata.words[w.wordId]) {
+          const hasBreak = w.newLine || ctxStudyMetadata.words[w.wordId]?.lineBreak;
+          if (hasBreak) {
+            ctxStudyMetadata.words[w.wordId] = {
+              ...(ctxStudyMetadata.words[w.wordId] || {}),
+              lineBreak: undefined,
+              ignoreNewLine: true,
+            };
+          } else if (ctxStudyMetadata.words[w.wordId]) {
             delete ctxStudyMetadata.words[w.wordId].lineBreak;
             delete ctxStudyMetadata.words[w.wordId].ignoreNewLine;
           }
@@ -163,7 +170,15 @@ const Passage = ({
             delete ctxStudyMetadata.words[bibleData[foundIndex].wordId].stropheDiv;
             delete ctxStudyMetadata.words[bibleData[foundIndex].wordId].stropheMd;
           }
-          const nextWordId = selectedWordId + 1;
+
+          for (let i = selectedWordId; i <= lastSelectedWordId; i++) {
+            if (ctxStudyMetadata.words[i]) {
+              delete ctxStudyMetadata.words[i].stropheDiv;
+              delete ctxStudyMetadata.words[i].stropheMd;
+            }
+          }
+
+          const nextWordId = lastSelectedWordId + 1;
           ctxStudyMetadata.words[nextWordId] = {
             ...(ctxStudyMetadata.words[nextWordId] || {}),
             stropheDiv: true
@@ -193,8 +208,16 @@ const Passage = ({
             ...(ctxStudyMetadata.words[selectedWordId] || {}),
             stropheDiv: true
           };
+
+          for (let i = selectedWordId + 1; i <= lastSelectedWordId; i++) {
+            if (ctxStudyMetadata.words[i]) {
+              delete ctxStudyMetadata.words[i].stropheDiv;
+              delete ctxStudyMetadata.words[i].stropheMd;
+            }
+          }
+
           const foundIndex = bibleData.findIndex(word =>
-            word.wordId > selectedWordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
+            word.wordId > lastSelectedWordId && ctxStudyMetadata.words[word.wordId]?.stropheDiv
           );
           if (foundIndex !== -1) {
             ctxStudyMetadata.words[bibleData[foundIndex].wordId] = {

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -500,23 +500,27 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
 
   const sortedWords = [...ctxSelectedWords].sort((a, b) => a.wordId - b.wordId);
   const firstSelectedWord = sortedWords[0];
+  const lastSelectedWord = sortedWords[sortedWords.length - 1];
   const sortedStrophes = [...ctxSelectedStrophes].sort((a, b) => a.lines[0].words[0].wordId - b.lines[0].words[0].wordId);
   const firstSelectedStrophe = sortedStrophes[0];
+  const lastSelectedStrophe = sortedStrophes[sortedStrophes.length - 1];
 
   if (updateType === StructureUpdateType.newLine) {
     buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
-    buttonEnabled = singleWordSelected && (ctxSelectedWords[0].lineId !== 0);
+    buttonEnabled = hasWordSelected && firstSelectedWord && firstSelectedWord.lineId !== 0;
   } else if (updateType === StructureUpdateType.mergeWithNextLine) {
-      buttonEnabled = singleWordSelected &&
-        ctxPassageProps.stanzaProps[ctxSelectedWords[0].stanzaId]
-        .strophes[ctxSelectedWords[0].stropheId]?.lines?.length - 1 !== ctxSelectedWords[0].lineId;
+      buttonEnabled = hasWordSelected && lastSelectedWord &&
+        ctxPassageProps.stanzaProps[lastSelectedWord.stanzaId]
+        .strophes[lastSelectedWord.stropheId]?.lines?.length - 1 !== lastSelectedWord.lineId;
   } else if (updateType === StructureUpdateType.newStrophe) {
     buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevStrophe) {
-    buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].firstStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].firstStropheInStanza));
+    buttonEnabled = ((hasWordSelected && firstSelectedWord && !firstSelectedWord.firstStropheInStanza) ||
+      (hasStropheSelected && firstSelectedStrophe && !firstSelectedStrophe.firstStropheInStanza));
   } else if (updateType === StructureUpdateType.mergeWithNextStrophe) {
-    buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].lastStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].lastStropheInStanza));
+    buttonEnabled = ((hasWordSelected && lastSelectedWord && !lastSelectedWord.lastStropheInStanza) ||
+      (hasStropheSelected && lastSelectedStrophe && !lastSelectedStrophe.lastStropheInStanza));
   } else if (updateType === StructureUpdateType.newStanza) {
     buttonEnabled = hasStrophesSelected && !!firstSelectedStrophe;
   } else if (updateType === StructureUpdateType.mergeWithPrevStanza) {

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -504,7 +504,7 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
   const firstSelectedStrophe = sortedStrophes[0];
 
   if (updateType === StructureUpdateType.newLine) {
-    buttonEnabled = hasWordSelected && firstSelectedWord && !firstSelectedWord.newLine && !firstSelectedWord.metadata?.lineBreak && !firstSelectedWord.firstWordInStrophe;
+    buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
     buttonEnabled = singleWordSelected && (ctxSelectedWords[0].lineId !== 0);
   } else if (updateType === StructureUpdateType.mergeWithNextLine) {
@@ -512,13 +512,13 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
         ctxPassageProps.stanzaProps[ctxSelectedWords[0].stanzaId]
         .strophes[ctxSelectedWords[0].stropheId]?.lines?.length - 1 !== ctxSelectedWords[0].lineId;
   } else if (updateType === StructureUpdateType.newStrophe) {
-    buttonEnabled = hasWordSelected && firstSelectedWord && (!firstSelectedWord.firstWordInStrophe);
+    buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevStrophe) {
     buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].firstStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].firstStropheInStanza));
   } else if (updateType === StructureUpdateType.mergeWithNextStrophe) {
     buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].lastStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].lastStropheInStanza));
   } else if (updateType === StructureUpdateType.newStanza) {
-    buttonEnabled = hasStrophesSelected && firstSelectedStrophe && (!firstSelectedStrophe.firstStropheInStanza);
+    buttonEnabled = hasStrophesSelected && !!firstSelectedStrophe;
   } else if (updateType === StructureUpdateType.mergeWithPrevStanza) {
     buttonEnabled = hasStrophesSelected && (ctxSelectedStrophes[0].lines[0].words[0].stanzaId !== undefined && ctxSelectedStrophes[0].lines[0].words[0].stanzaId > 0)
   } else if (updateType === StructureUpdateType.mergeWithNextStanza) {

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -493,26 +493,32 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
   const { ctxIsHebrew, ctxSelectedWords, ctxSetStructureUpdateType, ctxNumSelectedStrophes, ctxSelectedStrophes, ctxPassageProps } = useContext(FormatContext);
 
   let buttonEnabled = false;
-  let hasWordSelected = (ctxSelectedWords.length === 1);
+  let hasWordSelected = (ctxSelectedWords.length > 0);
+  let singleWordSelected = (ctxSelectedWords.length === 1);
   let hasStropheSelected = (ctxSelectedStrophes.length === 1);
-  let hasStrophesSelected = (ctxNumSelectedStrophes === 1) && (ctxPassageProps.stropheCount > 1) && (ctxSelectedStrophes[0] !== undefined);
+  let hasStrophesSelected = (ctxNumSelectedStrophes >= 1) && (ctxPassageProps.stropheCount > 1) && (ctxSelectedStrophes[0] !== undefined);
+
+  const sortedWords = [...ctxSelectedWords].sort((a, b) => a.wordId - b.wordId);
+  const firstSelectedWord = sortedWords[0];
+  const sortedStrophes = [...ctxSelectedStrophes].sort((a, b) => a.lines[0].words[0].wordId - b.lines[0].words[0].wordId);
+  const firstSelectedStrophe = sortedStrophes[0];
 
   if (updateType === StructureUpdateType.newLine) {
-    buttonEnabled = hasWordSelected && !ctxSelectedWords[0].newLine && !ctxSelectedWords[0].metadata?.lineBreak && !ctxSelectedWords[0].firstWordInStrophe;
+    buttonEnabled = hasWordSelected && firstSelectedWord && !firstSelectedWord.newLine && !firstSelectedWord.metadata?.lineBreak && !firstSelectedWord.firstWordInStrophe;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
-    buttonEnabled = hasWordSelected && (ctxSelectedWords[0].lineId !== 0);
+    buttonEnabled = singleWordSelected && (ctxSelectedWords[0].lineId !== 0);
   } else if (updateType === StructureUpdateType.mergeWithNextLine) {
-      buttonEnabled = hasWordSelected && 
+      buttonEnabled = singleWordSelected &&
         ctxPassageProps.stanzaProps[ctxSelectedWords[0].stanzaId]
         .strophes[ctxSelectedWords[0].stropheId]?.lines?.length - 1 !== ctxSelectedWords[0].lineId;
   } else if (updateType === StructureUpdateType.newStrophe) {
-    buttonEnabled = hasWordSelected && (!ctxSelectedWords[0].firstWordInStrophe);
+    buttonEnabled = hasWordSelected && firstSelectedWord && (!firstSelectedWord.firstWordInStrophe);
   } else if (updateType === StructureUpdateType.mergeWithPrevStrophe) {
-    buttonEnabled = (hasWordSelected && (!ctxSelectedWords[0].firstStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].firstStropheInStanza));
+    buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].firstStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].firstStropheInStanza));
   } else if (updateType === StructureUpdateType.mergeWithNextStrophe) {
-    buttonEnabled = (hasWordSelected && (!ctxSelectedWords[0].lastStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].lastStropheInStanza));
+    buttonEnabled = (singleWordSelected && (!ctxSelectedWords[0].lastStropheInStanza) || (hasStropheSelected && !ctxSelectedStrophes[0].lastStropheInStanza));
   } else if (updateType === StructureUpdateType.newStanza) {
-    buttonEnabled = hasStrophesSelected && (!ctxSelectedStrophes[0].firstStropheInStanza);
+    buttonEnabled = hasStrophesSelected && firstSelectedStrophe && (!firstSelectedStrophe.firstStropheInStanza);
   } else if (updateType === StructureUpdateType.mergeWithPrevStanza) {
     buttonEnabled = hasStrophesSelected && (ctxSelectedStrophes[0].lines[0].words[0].stanzaId !== undefined && ctxSelectedStrophes[0].lines[0].words[0].stanzaId > 0)
   } else if (updateType === StructureUpdateType.mergeWithNextStanza) {


### PR DESCRIPTION
## Summary
- allow new line creation with multiple word selections
- properly split strophes and stanzas above and below selection
- enable structure buttons for multiple selections

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6854d0e6fa1c83298c2c0dbe2f6ef728