### PR TITLE
Fix line merge button

### DIFF
--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -527,11 +527,9 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
     buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
     if (hasWordSelected && firstSelectedWord) {
-      const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]?.
-        strophes[firstSelectedWord.stropheId]?.
-        lines[firstSelectedWord.lineId];
-      const firstWordIdInLine = line?.words?.[0]?.wordId;
-      buttonEnabled = (firstWordIdInLine ?? firstSelectedWord.wordId) !== firstSelectedWord.wordId;
+      const firstWordIdInPassage =
+        ctxPassageProps.stanzaProps[0]?.strophes[0]?.lines[0]?.words[0]?.wordId;
+      buttonEnabled = firstSelectedWord.wordId !== firstWordIdInPassage;
     } else {
       buttonEnabled = false;
     }

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -527,12 +527,11 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
     buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
     if (hasWordSelected && firstSelectedWord) {
-      const lineWords = ctxPassageProps
-        .stanzaProps[firstSelectedWord.stanzaId]
-        .strophes[firstSelectedWord.stropheId]
-        .lines[firstSelectedWord.lineId].words;
-      const firstWordIdInLine = lineWords[0]?.wordId;
-      buttonEnabled = firstWordIdInLine !== firstSelectedWord.wordId;
+      const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]?.
+        strophes[firstSelectedWord.stropheId]?.
+        lines[firstSelectedWord.lineId];
+      const firstWordIdInLine = line?.words?.[0]?.wordId;
+      buttonEnabled = (firstWordIdInLine ?? firstSelectedWord.wordId) !== firstSelectedWord.wordId;
     } else {
       buttonEnabled = false;
     }

--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -526,7 +526,16 @@ export const StructureUpdateBtn = ({ updateType, toolTip }: { updateType: Struct
   if (updateType === StructureUpdateType.newLine) {
     buttonEnabled = hasWordSelected && !!firstSelectedWord;
   } else if (updateType === StructureUpdateType.mergeWithPrevLine) {
-    buttonEnabled = hasWordSelected && firstSelectedWord && firstSelectedWord.lineId !== 0;
+    if (hasWordSelected && firstSelectedWord) {
+      const lineWords = ctxPassageProps
+        .stanzaProps[firstSelectedWord.stanzaId]
+        .strophes[firstSelectedWord.stropheId]
+        .lines[firstSelectedWord.lineId].words;
+      const firstWordIdInLine = lineWords[0]?.wordId;
+      buttonEnabled = firstWordIdInLine !== firstSelectedWord.wordId;
+    } else {
+      buttonEnabled = false;
+    }
   } else if (updateType === StructureUpdateType.mergeWithNextLine) {
       buttonEnabled = hasWordSelected && lastSelectedWord &&
         ctxPassageProps.stanzaProps[lastSelectedWord.stanzaId]


### PR DESCRIPTION
## Summary
- when merging lines the first word retains a line index of `0`
- update the merge-with-prev-line check to verify the true start of the line

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_687bea1ed5ec83298470940be37b2c95