### PR TITLE
Add none option for color picker

### DIFF
--- a/src/components/StudyPane/Toolbar/Buttons.tsx
+++ b/src/components/StudyPane/Toolbar/Buttons.tsx
@@ -15,7 +15,7 @@ import { DEFAULT_COLOR_FILL, DEFAULT_BORDER_COLOR, DEFAULT_TEXT_COLOR, FormatCon
 import { BoxDisplayStyle, ColorActionType, ColorPickerProps, InfoPaneActionType, StructureUpdateType } from "@/lib/types";
 import { updateMetadataInDb } from "@/lib/actions";
 
-import { StudyMetadata, StropheProps } from '@/lib/data';
+import { StudyMetadata, StropheProps, ColorData } from '@/lib/data';
 
 export const ToolTip = ({ text }: { text: string }) => {
   return (
@@ -206,7 +206,62 @@ export const ColorActionBtn: React.FC<ColorPickerProps> = ({
     }
 
     (isChanged) && setStagedMetadata(ctxStudyMetadata);
-  } 
+  }
+
+  const handleClearColor = () => {
+    let defaultColor = "";
+    let colorProp = "";
+
+    switch (colorAction) {
+      case ColorActionType.colorFill:
+        defaultColor = DEFAULT_COLOR_FILL;
+        colorProp = "fill";
+        break;
+      case ColorActionType.borderColor:
+        defaultColor = DEFAULT_BORDER_COLOR;
+        colorProp = "border";
+        break;
+      case ColorActionType.textColor:
+        defaultColor = DEFAULT_TEXT_COLOR;
+        colorProp = "text";
+        break;
+      default:
+        return;
+    }
+
+    setSelectedColor("");
+    setDisplayColor(defaultColor);
+
+    let isChanged = false;
+
+    ctxSelectedWords.forEach((word) => {
+      const wordId = word.wordId;
+      const wordMetadata = ctxStudyMetadata.words[wordId];
+
+      if (wordMetadata && wordMetadata.color && (wordMetadata.color as any)[colorProp] !== undefined) {
+        isChanged = true;
+        delete (wordMetadata.color as any)[colorProp];
+
+        if (Object.keys(wordMetadata.color).length === 0) {
+          delete wordMetadata["color"];
+        }
+      }
+    });
+
+    if (ctxSelectedStrophes.length > 0) {
+      const selectedWordId = ctxSelectedStrophes[0].lines.at(0)?.words.at(0)?.wordId || 0;
+      const wordMetadata = ctxStudyMetadata.words[selectedWordId];
+        if (wordMetadata.stropheMd && wordMetadata.stropheMd.color && (wordMetadata.stropheMd.color as any)[colorProp] !== undefined) {
+          isChanged = true;
+          delete (wordMetadata.stropheMd.color as any)[colorProp];
+        if (Object.keys(wordMetadata.stropheMd.color).length === 0) {
+          delete wordMetadata.stropheMd.color;
+        }
+      }
+    }
+
+    (isChanged) && setStagedMetadata(ctxStudyMetadata);
+  };
 
   return (
     <div className="flex flex-col items-center justify-center px-2 xsm:flex-row ClickBlock">
@@ -241,6 +296,9 @@ export const ColorActionBtn: React.FC<ColorPickerProps> = ({
           <div className="relative z-10">
             <div className="absolute top-6 -left-6">
               <SwatchesPicker width={580} height={160} color={displayColor} onChange={handleColorPickerChange} />
+              <div className="mt-2 flex justify-center">
+                <button className="rounded border bg-white px-2 py-0.5 text-sm hover:bg-gray-100" onClick={handleClearColor}>None</button>
+              </div>
             </div>
           </div>
         )


### PR DESCRIPTION
## Summary
- add a button in the color picker overlay to clear the chosen color
- reset color of selected elements when choosing None

## Testing
- `npx tsc --noEmit`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_687bebc93c908329a40c124f76180284