### PR TITLE
Add Cypress setup for UI testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,25 @@ Follow the steps below to add your change:
 5. create a PR to merge your working branch into main in GitHub
 6. resolve comments from other team members and merge conflicts (if any)
 7. after your PR passes the check and is approved, it is ready to merge. Usually the admin will merge it for you. 
+
+## UI Testing with Cypress
+
+This project uses [Cypress](https://www.cypress.io/) for automated UI tests. Sample tests live under `cypress/e2e`. To run all tests locally:
+
+```bash
+npm run cypress
+```
+
+### Running Tagged Tests
+
+Tests can be tagged using the `tags` option. Use `cypress-grep` to execute a subset of tests:
+
+```bash
+npx cypress run --env grepTags=@smoke
+```
+
+### Adding More Tests
+
+Create new spec files in `cypress/e2e` and include assertions using `cy.*` commands. Assign tags in the test options to group related scenarios.
+
+

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "cypress";
+
+export default defineConfig({
+  e2e: {
+    baseUrl: "http://localhost:3000",
+    specPattern: "cypress/e2e/**/*.cy.{ts,tsx}",
+    supportFile: "cypress/support/e2e.ts",
+    setupNodeEvents(on, config) {
+      require("cypress-grep/src/plugin")(config);
+      return config;
+    },
+  },
+});

--- a/cypress/e2e/sample.cy.ts
+++ b/cypress/e2e/sample.cy.ts
@@ -1,0 +1,8 @@
+// @ts-check
+
+describe('Navigation', { tags: '@smoke' }, () => {
+  it('loads the sign up page', () => {
+    cy.visit('/sign-up');
+    cy.contains('SignUp');
+  });
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,0 +1,3 @@
+import 'cypress-grep';
+
+// Add custom commands if needed

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "cypress": "cypress open",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.5",
@@ -28,6 +30,8 @@
     "@types/react-color": "^3.0.12",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
+    "cypress": "^13.6.5",
+    "cypress-grep": "^3.1.2",
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.2.6",
     "postcss": "^8.4.34",


### PR DESCRIPTION
## Summary
- integrate Cypress with cypress-grep plugin for tagged test execution
- add a sample tagged test
- document how to run and extend Cypress tests

## Testing
- `npm run test:e2e` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_b_687bf413bedc83298c4878b2c15226af