### PR TITLE
Fix merge-with-previous-line selection behavior

### DIFF
--- a/src/components/StudyPane/Passage/index.tsx
+++ b/src/components/StudyPane/Passage/index.tsx
@@ -39,11 +39,17 @@ const Passage = ({
 
       if (sortedWords.length === 1) {
         if (ctxStructureUpdateType === StructureUpdateType.newLine ||
-            ctxStructureUpdateType === StructureUpdateType.mergeWithPrevLine ||
             ctxStructureUpdateType === StructureUpdateType.mergeWithNextLine) {
           const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]
             .strophes[firstSelectedWord.stropheId].lines[firstSelectedWord.lineId];
           lastSelectedWordId = line.words[line.words.length - 1].wordId;
+        } else if (ctxStructureUpdateType === StructureUpdateType.mergeWithPrevLine) {
+          const line = ctxPassageProps.stanzaProps[firstSelectedWord.stanzaId]
+            .strophes[firstSelectedWord.stropheId].lines[firstSelectedWord.lineId];
+          const isLineStart = line.words[0]?.wordId === selectedWordId;
+          if (isLineStart) {
+            lastSelectedWordId = line.words[line.words.length - 1].wordId;
+          }
         } else if (ctxStructureUpdateType === StructureUpdateType.newStrophe ||
                    ctxStructureUpdateType === StructureUpdateType.mergeWithPrevStrophe ||
                    ctxStructureUpdateType === StructureUpdateType.mergeWithNextStrophe) {


### PR DESCRIPTION
## Summary
- ensure merging with the previous line only expands to the whole line when the selection begins the line
- keep mid-line "merge with previous line" selections from pulling trailing words upward

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68d9c28573908329bf1708fe27ab18e6